### PR TITLE
Changed the final inconsistent metacard attributes key to align with the others

### DIFF
--- a/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
@@ -538,6 +538,7 @@ public class CatalogMethods implements MethodSet {
     return ImmutableMap.<String, Object>builder()
         .put(ATTRIBUTES, metacardAttributes2map(metacard))
         .put("metacardType", metacard.getMetacardType().getName())
+        .put("sourceId", metacard.getSourceId())
         .build();
   }
 

--- a/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
@@ -202,7 +202,6 @@ public class CatalogMethods implements MethodSet {
             .getDeletedMetacards()
             .stream()
             .map(this::metacard2map)
-            .map(m -> ImmutableMap.of(ATTRIBUTES, m))
             .collect(Collectors.toList()));
   }
 
@@ -251,7 +250,6 @@ public class CatalogMethods implements MethodSet {
             .stream()
             .map(Update::getNewMetacard)
             .map(this::metacard2map)
-            .map(v -> ImmutableMap.of(ATTRIBUTES, v))
             .collect(Collectors.toList()));
   }
 
@@ -427,7 +425,7 @@ public class CatalogMethods implements MethodSet {
 
   private Map<String, Object> getMetacardInfo(Metacard metacard) {
     return new ImmutableMap.Builder<String, Object>()
-        .put("metacard", ImmutableMap.of("properties", this.metacard2map(metacard)))
+        .put("metacard", metacard2map(metacard))
         .put("actions", getMetacardActions(metacard))
         .build();
   }
@@ -449,7 +447,9 @@ public class CatalogMethods implements MethodSet {
   }
 
   private Map<String, List<FacetValueCount>> getFacetResults(Serializable facetResults) {
-    if (!(facetResults instanceof List)) return Collections.emptyMap();
+    if (!(facetResults instanceof List)) {
+      return Collections.emptyMap();
+    }
     List<Object> list = (List<Object>) facetResults;
     return list.stream()
         .filter(result -> result instanceof FacetAttributeResult)
@@ -531,11 +531,17 @@ public class CatalogMethods implements MethodSet {
             .getCreatedMetacards()
             .stream()
             .map(this::metacard2map)
-            .map(v -> ImmutableMap.of(ATTRIBUTES, v))
             .collect(Collectors.toList()));
   }
 
   private Map<String, Object> metacard2map(Metacard metacard) {
+    return ImmutableMap.<String, Object>builder()
+        .put(ATTRIBUTES, metacardAttributes2map(metacard))
+        .put("metacardType", metacard.getMetacardType().getName())
+        .build();
+  }
+
+  private Map<String, Object> metacardAttributes2map(Metacard metacard) {
     Builder<String, Object> builder = ImmutableMap.builder();
     for (AttributeDescriptor ad : metacard.getMetacardType().getAttributeDescriptors()) {
       Attribute attribute = metacard.getAttribute(ad.getName());
@@ -667,6 +673,7 @@ public class CatalogMethods implements MethodSet {
   }
 
   private static class FilterTreeParseException extends RuntimeException {
+
     private FilterTreeParseException(String msg) {
       super(msg);
     }

--- a/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
@@ -537,7 +537,7 @@ public class CatalogMethods implements MethodSet {
   private Map<String, Object> metacard2map(Metacard metacard) {
     return ImmutableMap.<String, Object>builder()
         .put(ATTRIBUTES, metacardAttributes2map(metacard))
-        .put("metacardType", metacard.getMetacardType().getName())
+        .put("metacardType", ImmutableMap.of("name", metacard.getMetacardType().getName()))
         .put("sourceId", metacard.getSourceId())
         .build();
   }


### PR DESCRIPTION
All places were using the same structure and keys naming as the catalog api except for one final place in the query results. This aligns this so all result structures are the same. 