### PR TITLE
Replace Created and Modified with Metacard_*

### DIFF
--- a/src/main/java/com/connexta/ddf/catalog/direct/ExtendedMethods.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/ExtendedMethods.java
@@ -126,8 +126,8 @@ public class ExtendedMethods implements MethodSet {
         metacardToClone,
         Arrays.asList(
             Core.ID,
-            Core.CREATED,
-            Core.MODIFIED,
+            Core.METACARD_CREATED,
+            Core.METACARD_MODIFIED,
             Core.METACARD_OWNER,
             Security.ACCESS_ADMINISTRATORS,
             Security.ACCESS_GROUPS,


### PR DESCRIPTION
Core.Created and Core.Modified reference the related resource (i.e. document, image etc.) whereas Metacard_* references the metacard itself