### PR TITLE
Make returning subscriptions optional

### DIFF
--- a/src/main/java/com/connexta/ddf/persistence/subscriptions/SubscriptionMethods.java
+++ b/src/main/java/com/connexta/ddf/persistence/subscriptions/SubscriptionMethods.java
@@ -1,7 +1,5 @@
 package com.connexta.ddf.persistence.subscriptions;
 
-import static org.apache.commons.lang3.Validate.notBlank;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +48,10 @@ public class SubscriptionMethods {
   }
 
   public List<String> getSubscriptions(String email) {
-    notBlank(email, "email must not be blank");
+    if (email == null || email.trim().isEmpty()) {
+      LOGGER.trace("No email given for subscriptions");
+      return Collections.emptyList();
+    }
     LOCK.lock();
     try {
       List<Map<String, Object>> results = query(email);

--- a/src/test/java/com/connexta/ddf/persistence/subscriptions/SubscriptionMethodsTest.java
+++ b/src/test/java/com/connexta/ddf/persistence/subscriptions/SubscriptionMethodsTest.java
@@ -40,9 +40,10 @@ public class SubscriptionMethodsTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testEmptyEmail() throws Exception {
-    testSubscription.getSubscriptions("");
+  @Test
+  public void testEmptyEmail() {
+    List<String> results = testSubscription.getSubscriptions("");
+    assertThat(results, is(Collections.emptyList()));
   }
 
   @Test


### PR DESCRIPTION
Enables the use of catalog methods in cases where the email address might not be available.