### PR TITLE
CatalogMethod expects sorts in list, not map

### DIFF
--- a/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
@@ -318,9 +318,10 @@ public class CatalogMethods implements MethodSet {
     }
 
     SortBy sortPolicy = SortBy.NATURAL_ORDER;
-    if (params.containsKey("sortPolicy")) {
-      if (params.get("sortPolicy") instanceof Map) {
-        Map<String, Object> rawSortPolicy = (Map) params.get("sortPolicy");
+    if (params.containsKey("sortPolicy") && params.get("sortPolicy") instanceof List) {
+      List sortList = (List) params.get("sortPolicy");
+      if (!sortList.isEmpty() && sortList.get(0) instanceof Map) {
+        Map<String, Object> rawSortPolicy = (Map) sortList.get(0);
 
         if (!(rawSortPolicy.get("propertyName") instanceof String)) {
           return new Error(


### PR DESCRIPTION
Revelio's schema defines `sortPolicy` as a list; right now, ddf-jsonrpc expects it to be a map. The sort is never added to the request, and is ignored. 

Schema is defined here:
https://github.com/connexta/revelio/blob/master/schema.json#L359

Here, we change it to expect a list, and try to grab the first item of the list to use as a sort. 