### PR TITLE
Adds ability to save and return lists

### DIFF
--- a/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
@@ -149,19 +149,23 @@ public class CatalogMethods implements MethodSet {
 
   private SubscriptionMethods subscription;
 
+  private MetacardMap metacardMap;
+
   public CatalogMethods(
       CatalogFramework catalogFramework,
       AttributeRegistry attributeRegistry,
       List<MetacardType> metacardTypes,
       FilterBuilder filterBuilder,
       ActionRegistry actionRegistry,
-      SubscriptionMethods subscription) {
+      SubscriptionMethods subscription,
+      MetacardMap metacardMap) {
     this.catalogFramework = catalogFramework;
     this.attributeRegistry = attributeRegistry;
     this.metacardTypes = metacardTypes;
     this.filterBuilder = filterBuilder;
     this.actionRegistry = actionRegistry;
     this.subscription = subscription;
+    this.metacardMap = metacardMap;
   }
 
   private Object getSourceIds(Map<String, Object> params) {
@@ -209,7 +213,7 @@ public class CatalogMethods implements MethodSet {
         deleteResponse
             .getDeletedMetacards()
             .stream()
-            .map(MetacardMap::convert)
+            .map(metacardMap::convert)
             .collect(Collectors.toList()));
   }
 
@@ -257,7 +261,7 @@ public class CatalogMethods implements MethodSet {
             .getUpdatedMetacards()
             .stream()
             .map(Update::getNewMetacard)
-            .map(MetacardMap::convert)
+            .map(metacardMap::convert)
             .collect(Collectors.toList()));
   }
 
@@ -445,12 +449,12 @@ public class CatalogMethods implements MethodSet {
       Metacard metacard, List<String> workspaceSubscriptionIds) {
     return isWorkspace(metacard)
         ? new ImmutableMap.Builder<String, Object>()
-            .put("metacard", MetacardMap.convert(metacard))
+            .put("metacard", metacardMap.convert(metacard))
             .put("actions", getMetacardActions(metacard))
             .put("isSubscribed", isSubscribed(metacard, workspaceSubscriptionIds))
             .build()
         : new ImmutableMap.Builder<String, Object>()
-            .put("metacard", MetacardMap.convert(metacard))
+            .put("metacard", metacardMap.convert(metacard))
             .put("actions", getMetacardActions(metacard))
             .build();
   }
@@ -556,7 +560,7 @@ public class CatalogMethods implements MethodSet {
         createResponse
             .getCreatedMetacards()
             .stream()
-            .map(MetacardMap::convert)
+            .map(metacardMap::convert)
             .collect(Collectors.toList()));
   }
 

--- a/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
@@ -6,6 +6,7 @@ import static ddf.catalog.Constants.EXPERIMENTAL_FACET_RESULTS_KEY;
 import static org.apache.commons.lang3.tuple.ImmutablePair.of;
 
 import com.connexta.ddf.persistence.subscriptions.SubscriptionMethods;
+import com.connexta.ddf.transformer.RpcListHandler;
 import com.connexta.jsonrpc.DocMethod;
 import com.connexta.jsonrpc.Error;
 import com.connexta.jsonrpc.JsonRpc;
@@ -151,6 +152,8 @@ public class CatalogMethods implements MethodSet {
 
   private MetacardMap metacardMap;
 
+  private RpcListHandler listHandler;
+
   public CatalogMethods(
       CatalogFramework catalogFramework,
       AttributeRegistry attributeRegistry,
@@ -158,7 +161,8 @@ public class CatalogMethods implements MethodSet {
       FilterBuilder filterBuilder,
       ActionRegistry actionRegistry,
       SubscriptionMethods subscription,
-      MetacardMap metacardMap) {
+      MetacardMap metacardMap,
+      RpcListHandler listHandler) {
     this.catalogFramework = catalogFramework;
     this.attributeRegistry = attributeRegistry;
     this.metacardTypes = metacardTypes;
@@ -166,6 +170,7 @@ public class CatalogMethods implements MethodSet {
     this.actionRegistry = actionRegistry;
     this.subscription = subscription;
     this.metacardMap = metacardMap;
+    this.listHandler = listHandler;
   }
 
   private Object getSourceIds(Map<String, Object> params) {
@@ -582,6 +587,11 @@ public class CatalogMethods implements MethodSet {
     Metacard result = new MetacardImpl(metacardType);
 
     for (Entry<String, Object> entry : attributes.entrySet()) {
+      if (entry.getKey().equals("lists")) {
+        result.setAttribute(
+            new AttributeImpl(entry.getKey(), listHandler.listMetacardsToXml(entry.getValue())));
+        continue;
+      }
       ImmutablePair<Attribute, String> res = getAttribute(entry.getKey(), entry.getValue());
       if (res.getRight() != null) {
         return of(null, res.getRight());

--- a/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
@@ -587,7 +587,7 @@ public class CatalogMethods implements MethodSet {
     Metacard result = new MetacardImpl(metacardType);
 
     for (Entry<String, Object> entry : attributes.entrySet()) {
-      if (entry.getKey().equals("lists")) {
+      if (entry.getKey().equals(MetacardMap.LISTS)) {
         result.setAttribute(
             new AttributeImpl(entry.getKey(), listHandler.listMetacardsToXml(entry.getValue())));
         continue;

--- a/src/main/java/com/connexta/ddf/catalog/direct/ExtendedMethods.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/ExtendedMethods.java
@@ -50,6 +50,8 @@ public class ExtendedMethods implements MethodSet {
 
   private final Map<String, DocMethod> METHODS;
 
+  private static final MetacardMap metacardMap = new MetacardMap(null);
+
   {
     Builder<String, DocMethod> builder = ImmutableMap.builder();
     builder.put(
@@ -97,7 +99,7 @@ public class ExtendedMethods implements MethodSet {
 
     return ImmutableMap.of(
         CREATED_METACARDS_KEY,
-        ((List<Metacard>) result).stream().map(MetacardMap::convert).collect(Collectors.toList()));
+        ((List<Metacard>) result).stream().map(metacardMap::convert).collect(Collectors.toList()));
   }
 
   private Object doClone(String id) {

--- a/src/main/java/com/connexta/ddf/catalog/direct/MetacardMap.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/MetacardMap.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 
 public class MetacardMap {
 
-  private static final String LISTS = "lists";
+  public static final String LISTS = "lists";
 
   private final RpcListHandler listHandler;
 

--- a/src/main/java/com/connexta/ddf/transformer/ListTransformationException.java
+++ b/src/main/java/com/connexta/ddf/transformer/ListTransformationException.java
@@ -1,7 +1,7 @@
 package com.connexta.ddf.transformer;
 
 public class ListTransformationException extends RuntimeException {
-    public ListTransformationException(Exception e){
-        super(e);
-    }
+  public ListTransformationException(Exception e) {
+    super(e);
+  }
 }

--- a/src/main/java/com/connexta/ddf/transformer/ListTransformationException.java
+++ b/src/main/java/com/connexta/ddf/transformer/ListTransformationException.java
@@ -1,0 +1,7 @@
+package com.connexta.ddf.transformer;
+
+public class ListTransformationException extends RuntimeException {
+    public ListTransformationException(Exception e){
+        super(e);
+    }
+}

--- a/src/main/java/com/connexta/ddf/transformer/RpcListHandler.java
+++ b/src/main/java/com/connexta/ddf/transformer/RpcListHandler.java
@@ -98,7 +98,7 @@ public class RpcListHandler {
       InputStream inputStream = IOUtils.toInputStream(xml, Charset.defaultCharset());
       return inputTransformer.transform(inputStream);
     } catch (IOException | CatalogTransformerException ex) {
-      throw new RuntimeException(ex);
+      throw new ListTransformationException(ex);
     }
   }
 
@@ -106,7 +106,7 @@ public class RpcListHandler {
     try (InputStream stream = catalogFramework.transform(metacard, "xml", null).getInputStream()) {
       return IOUtils.toString(stream, Charset.defaultCharset());
     } catch (IOException | CatalogTransformerException e) {
-      throw new RuntimeException(e);
+      throw new ListTransformationException(e);
     }
   }
 }

--- a/src/main/java/com/connexta/ddf/transformer/RpcListHandler.java
+++ b/src/main/java/com/connexta/ddf/transformer/RpcListHandler.java
@@ -1,0 +1,70 @@
+package com.connexta.ddf.transformer;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.AttributeDescriptor;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.MetacardType;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.InputTransformer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.io.IOUtils;
+
+public class RpcListHandler {
+  private InputTransformer inputTransformer;
+
+  private static final String listMetacardTypeName = "metacard.list";
+
+  private MetacardType listMetacardType;
+
+  public RpcListHandler(InputTransformer inputTransformer, List<MetacardType> metacardTypes) {
+    this.inputTransformer = inputTransformer;
+    this.listMetacardType =
+        metacardTypes
+            .stream()
+            .filter(mt -> mt.getName().equals(listMetacardTypeName))
+            .findFirst()
+            .orElse(null);
+  }
+
+  public List<Map<String, Object>> listsXmlToMaps(List<Serializable> listsXml) {
+    return listsXml
+        .stream()
+        .map(String.class::cast)
+        .map(this::listXmlToMetacard)
+        .map(this::listMetacardToMap)
+        .collect(Collectors.toList());
+  }
+
+  private Map<String, Object> listMetacardToMap(Metacard listMetacard) {
+    Builder<String, Object> listMap = new ImmutableMap.Builder<>();
+    for (AttributeDescriptor ad : listMetacardType.getAttributeDescriptors()) {
+      Attribute attribute = listMetacard.getAttribute(ad.getName());
+      if (attribute == null) {
+        continue;
+      }
+      if (ad.isMultiValued()) {
+        listMap.put(attribute.getName(), attribute.getValues());
+      } else {
+        listMap.put(attribute.getName(), attribute.getValue());
+      }
+    }
+    return listMap.build();
+  }
+
+  private Metacard listXmlToMetacard(String xml) {
+    try {
+      InputStream inputStream = IOUtils.toInputStream(xml, Charset.defaultCharset());
+      return inputTransformer.transform(inputStream);
+    } catch (IOException | CatalogTransformerException ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+}

--- a/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -68,6 +68,7 @@
     <argument ref="metacardActionRegistry"/>
     <argument ref="subscriptionMethods"/>
     <argument ref="metacardMap" />
+    <argument ref="listHandler" />
     <!--    <cm:managed-properties persistent-id="com.connexta.ddf.resourcemanagement.usage"-->
     <!--      update-strategy="container-managed"/>-->
     <!--    <property name="monitorLocalSources" value="false"/>-->

--- a/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -40,11 +40,24 @@
   <reference id="defaultAttributeValidatorRegistry" interface="ddf.catalog.validation.AttributeValidatorRegistry" availability="optional"/>
   
   <reference-list id="attributeInjectors" interface="ddf.catalog.data.AttributeInjector" availability="optional"/>
+
+  <reference id="inputTransformer" interface="ddf.catalog.transform.InputTransformer"
+  filter="(id=xml)"/>
   
   <bean id="enumerationExtractor" class="com.connexta.ddf.attribute.enumerations.EnumerationExtractor">
     <argument ref="defaultAttributeValidatorRegistry"/>
     <argument ref="metacardTypes"/>
     <argument ref="attributeInjectors"/>
+  </bean>
+
+  <bean id="listHandler" class="com.connexta.ddf.transformer.RpcListHandler">
+    <argument ref="inputTransformer" />
+    <argument ref="catalogFramework"/>
+    <argument ref="metacardTypes" />
+  </bean>
+
+  <bean id="metacardMap" class="com.connexta.ddf.catalog.direct.MetacardMap">
+    <argument ref="listHandler" />
   </bean>
 
   <bean id="catalogMethods" class="com.connexta.ddf.catalog.direct.CatalogMethods">
@@ -54,6 +67,7 @@
     <argument ref="filterBuilder"/>
     <argument ref="metacardActionRegistry"/>
     <argument ref="subscriptionMethods"/>
+    <argument ref="metacardMap" />
     <!--    <cm:managed-properties persistent-id="com.connexta.ddf.resourcemanagement.usage"-->
     <!--      update-strategy="container-managed"/>-->
     <!--    <property name="monitorLocalSources" value="false"/>-->


### PR DESCRIPTION
We store lists as embedded metacards on workspaces. This currently makes us make two requests for every workspace, one to the direct endpoint, and then one to the old workspaces endpoint to get the lists in JSON format for revelio. This minimally adds some of the old workspace endpoint functionality so those extra workspace endpoint calls are unnecessary. 