### PR TITLE
Fix querying of non-local sources

### DIFF
--- a/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
+++ b/src/main/java/com/connexta/ddf/catalog/direct/CatalogMethods.java
@@ -467,7 +467,8 @@ public class CatalogMethods implements MethodSet {
   }
 
   private boolean isWorkspace(Metacard metacard) {
-    return metacard.getAttribute("metacard-tags").getValues().contains("workspace");
+    return metacard.getAttribute("metacard-tags") != null
+        && metacard.getAttribute("metacard-tags").getValues().contains("workspace");
   }
 
   private Map<String, Object> getMetacardInfo(


### PR DESCRIPTION
The metacard returned from a query request to the catalogFramework, such as those specifying a non-local source, does not always have a `metacard-tags` attribute.