### PR TITLE
Upgrade DDF to 2.29.15

### DIFF
--- a/ddf-rpc-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/ddf-rpc-api/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -134,7 +134,10 @@
 
   <service ref="jsonRpcHttpServlet" interface="javax.servlet.Servlet">
     <service-properties>
-      <entry key="urlPatterns" value="/direct/*"/>
+      <entry key="osgi.http.whiteboard.servlet.pattern" value="/direct/*"/>
+      <entry key="osgi.http.whiteboard.servlet.name" value="jsonRpcHttpServlet" />
+      <entry key="osgi.http.whiteboard.select" value="(osg.http.whiteboard.context.name=jsonRpcHttpServlet)" />
+      <entry key="osgi.http.whiteboard.servlet.asyncSupported" value="true" />
     </service-properties>
   </service>
 </blueprint>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <ddf.version>2.29.1</ddf.version>
+    <ddf.version>2.29.13</ddf.version>
     <ddf.support.version>2.3.16</ddf.support.version>
 
     <opengis.version>24.6</opengis.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <ddf.version>2.29.13</ddf.version>
+    <ddf.version>2.29.15</ddf.version>
     <ddf.support.version>2.3.16</ddf.support.version>
 
     <opengis.version>24.6</opengis.version>


### PR DESCRIPTION
Would like to wait for a future release of 2.29.x when the following are included:

- https://github.com/codice/ddf/commit/cf1e79169a8ec9f3f7d33b5c3229de235b329150
- A CXF upgrade to 3.5.12

But would be happy with this intermediate upgrade. 